### PR TITLE
feat(ts-lint): atualiza propriedades depreciadas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 2.0.0-beta.2 (03/04/2020)
+
+### Features
+
+* **lint:** atualiza propriedades depreciadas ([9df5ba6](https://github.com/po-ui/po-tslint/commit/9df5ba6e0fc0fa707b0d0fb3939838518e73b621))
+
 # 2.0.0-beta.1 (19/03/2020)
 
 Atualização para Angular v9.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@po-ui/ng-tslint",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "tag": "beta",
   "description": "PO Lint for TSLint",
   "author": "PO",

--- a/po-tslint.json
+++ b/po-tslint.json
@@ -34,8 +34,14 @@
     "member-access": false,
     "member-ordering": [
       true,
-      "static-before-instance",
-      "variables-before-functions"
+      {
+        "order": [
+          "static-field", 
+          "instance-field", 
+          "constructor", 
+          "instance-method"
+        ]
+      }
     ],
     "no-arg": true,
     "no-bitwise": true,
@@ -64,7 +70,6 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [
@@ -129,7 +134,6 @@
     "no-host-metadata-property": true,
     "no-input-rename": false,
     "no-output-rename": false,
-    "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
     "directive-class-suffix": true,


### PR DESCRIPTION
Com a atualização dos pacotes no po-angular, foi necessário remover a propriedade "no-use-before-declare" e também redefinir os valores para "member-ordering"

Fixes DTHFUI-3262