### PR TITLE
fix(lint): desabilita regras do tslint-sonar

### DIFF
--- a/po-tslint.json
+++ b/po-tslint.json
@@ -155,6 +155,8 @@
       "generic"
     ],
     "no-duplicate-string": false,
-    "ordered-imports": false
+    "ordered-imports": false,
+    "bool-param-default": false,
+    "arguments-order": false
   }
 }


### PR DESCRIPTION
As regras novas vieram a partir da atualização do tslint-sonar.
As regras serão desabilitadas provisoriamente