### PR TITLE
feat(ng-tslint): nova regra `bool-param-default`

### DIFF
--- a/po-tslint.json
+++ b/po-tslint.json
@@ -156,7 +156,7 @@
     ],
     "no-duplicate-string": false,
     "ordered-imports": false,
-    "bool-param-default": false,
+    "bool-param-default": true,
     "arguments-order": false
   }
 }


### PR DESCRIPTION
Nova regra `bool-param-default` para ter um valor padrão para parâmetros opcionais booleanos, para tornar a lógica do método mais evidente.

Fixes DTHFUI-3909