### PR TITLE
build(actions): cria ação de publicação do pacote

### DIFF
--- a/.github/publish_ci.yml
+++ b/.github/publish_ci.yml
@@ -1,0 +1,30 @@
+name: Publish @po-ui/ng-tslint
+on:
+  workflow_dispatch:
+  
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+        
+    - run: npm install
+      
+    - name: Get package.json version
+      id: package-version
+      uses: martinbeentjes/npm-get-version-action@master
+      
+    - name: Run publish
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+ 
+    - name: Add "latest" tag
+      if: (!contains(steps.package-version.outputs.current-version, '-next') && !contains(steps.package-version.outputs.current-version, '-rc'))
+      run: npm dist-tags add @po-ui/ng-tslint@${{ steps.package-version.outputs.current-version }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@po-ui/ng-tslint",
   "version": "3.0.0",
-  "tag": "beta",
+  "tag": "next",
   "description": "PO Lint for TSLint",
   "author": "PO",
   "license": "MIT",


### PR DESCRIPTION
@po-ui/ng-tslint

DTHFUI-4136

Adiciona no github actions uma ação para publicar o pacote de forma automatizada.
Substitui a tag `dev` do package.json para `next`, para a partir dali o pacote ser publicado utilizando a tag next e latest.

Para testar:

Para chegar em um teste mais próximo, pode ser utilizado o repositório: [para testes](https://github.com/samir-ayoub/po-tslint-test-github-actions). Utilize esse repositório para subir as versões e executar as actions.

Altere para uma nova versão no package.json
`git commit` e `git push`
git tag <versão> 
git push origin <versão>

Acesse abra a aba actions do repositório, clique em `Publish @po-ui/ng-tslint`, posteriormente em `Run Workflow` veja a execução do fluxo de trabalho.

Favor testar também versão com tags -rc e -next

Verificar também nossa [doc sobre o processo de release](https://docs.google.com/document/d/1-eQpYVVBZLpkgZEuZ4a2ycXtS2-pcCwuB2QOS97D-zM/edit#)